### PR TITLE
Added object to separate out yaml documents in the same file/input

### DIFF
--- a/separator.go
+++ b/separator.go
@@ -1,0 +1,68 @@
+package yaml
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+)
+
+const yamlSeparator = "\n---"
+const separator = "---"
+
+type Separator interface {
+	Next() ([]byte, error)
+}
+
+type YAMLSeparator struct {
+	scanner *bufio.Scanner
+}
+
+func NewYAMLDocumentSeparator(reader io.Reader) Separator {
+	scanner := bufio.NewScanner(reader)
+	scanner.Split(splitYAMLDocument)
+	return &YAMLSeparator{
+		scanner: scanner,
+	}
+}
+
+// Code originally taken from https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go#L142
+func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	sep := len([]byte(yamlSeparator))
+	if i := bytes.Index(data, []byte(yamlSeparator)); i >= 0 {
+		// We have a potential document terminator
+		i += sep
+		after := data[i:]
+		if len(after) == 0 {
+			// we can't read any more characters
+			if atEOF {
+				return len(data), data[:len(data)-sep], nil
+			}
+			return 0, nil, nil
+		}
+		if j := bytes.IndexByte(after, '\n'); j >= 0 {
+			return i + j + 1, data[0 : i-sep], nil
+		}
+		return 0, nil, nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+func (t *YAMLSeparator) Next() ([]byte, error) {
+	if !t.scanner.Scan() {
+		err := t.scanner.Err()
+		if err == nil {
+			err = io.EOF
+		}
+		return []byte{}, err
+	}
+
+	return t.scanner.Bytes(), nil
+}

--- a/separator_test.go
+++ b/separator_test.go
@@ -1,0 +1,86 @@
+package yaml
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestSplitYAMLDocument(t *testing.T) {
+	testCases := []struct {
+		input  string
+		atEOF  bool
+		expect string
+		adv    int
+	}{
+		{"foo", true, "foo", 3},
+		{"fo", false, "", 0},
+
+		{"---", true, "---", 3},
+		{"---\n", true, "---\n", 4},
+		{"---\n", false, "", 0},
+
+		{"\n---\n", false, "", 5},
+		{"\n---\n", true, "", 5},
+
+		{"abc\n---\ndef", true, "abc", 8},
+		{"def", true, "def", 3},
+		{"", true, "", 0},
+	}
+	for i, testCase := range testCases {
+		adv, token, err := splitYAMLDocument([]byte(testCase.input), testCase.atEOF)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			continue
+		}
+		if adv != testCase.adv {
+			t.Errorf("%d: advance did not match: %d %d", i, testCase.adv, adv)
+		}
+		if testCase.expect != string(token) {
+			t.Errorf("%d: token did not match: %q %q", i, testCase.expect, string(token))
+		}
+	}
+}
+
+func TestYAMLSeparatorNext(t *testing.T) {
+	reader := bytes.NewReader([]byte(testYAMLDocFull))
+	separator := NewYAMLDocumentSeparator(reader)
+	doc1, err := separator.Next()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !bytes.Equal([]byte(testYAMLDoc1), doc1) {
+		t.Errorf("%s does not match %s", testYAMLDoc1, doc1)
+	}
+	doc2, err := separator.Next()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !bytes.Equal([]byte(testYAMLDoc2), doc2) {
+		t.Errorf("%s does not match %s", testYAMLDoc2, doc2)
+	}
+	extra, err := separator.Next()
+	if err == nil {
+		t.Error("expected EOF error but got none")
+	}
+	if len(extra) > 0 {
+		t.Errorf("%v is not empty after the entire document has been scanned", extra)
+	}
+}
+
+const testYAMLDoc1 = `
+a: TestFieldA
+b: TestFieldB
+c:
+  c1: TestFieldC1
+  c2: TestFieldC2`
+
+const testYAMLDoc2 = `
+d: TestFieldD
+e: TestFieldE
+f:
+  - name: TestFieldFListItem1
+  - name: TestFieldFListItem2`
+
+const testYAMLDocFull = testYAMLDoc1 + `
+---
+` + testYAMLDoc2


### PR DESCRIPTION
## Description
Added an object that can be used to iterate over multiple YAML documents from the same input

Should help with solving https://github.com/projectcalico/libcalico-go/issues/47

## Testing
Added unit tests